### PR TITLE
update the plugin to fix localization-not-working

### DIFF
--- a/simple-post-expiration.php
+++ b/simple-post-expiration.php
@@ -45,7 +45,7 @@ require_once dirname( __FILE__ ) . '/includes/widgets.php';
 function pw_spe_text_domain() {
 
 	// Load the default language files
-	load_plugin_textdomain( 'pw-spe' );
+	load_plugin_textdomain('pw-spe', false, plugin_basename(dirname(__FILE__)). '/languages');
 
 }
 add_action( 'init', 'pw_spe_text_domain' );


### PR DESCRIPTION
This one line change should update the plugin to make the localization work once again.

The symptom was found during this .org forum support conversation: https://wordpress.org/support/topic/language-translation-26